### PR TITLE
Add npm for managing front-end dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 
 # Ignore vendored gems
 vendor/ruby
+
+# Ignore node modules
+/node_modules

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+production=true

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Want to contribute to WorkingScholar?  We welcome
 
 ### Requirements
 
+#### Database
+
 We use [PostgreSQL](http://www.postgresql.org/) as our datastore.
 
 On OS X, install PostgreSQL through [Homebrew](http://brew.sh/):
@@ -60,12 +62,18 @@ where ENVIRONMENT is one of `development`, `test`, `production`.
 
 > **Note**: the database name __**is**__ case-sensitive.
 
+#### Dependency Managers
+
+- [Bundler](http://bundler.io/)
+- [npm](https://www.npmjs.com/package/npm) (Bundled with [NodeJS](https://nodejs.org/))
+
 ### Installation & Setup
 
 Install the application dependencies with:
 
 ```sh
 bundle install --path vendor
+npm install
 ```
 
 ### Running the Application

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,8 @@ module WorkingScholar
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    # Add npm modules to assets path
+    config.assets.paths << Rails.root.join("node_modules")
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "WorkingScholar",
+  "version": "0.1.0",
+  "description": "A micro-consulting platform that empowers students to build their professional experience.",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/WorkingScholar/workingscholar.git"
+  },
+  "bugs": {
+    "url": "https://github.com/WorkingScholar/workingscholar/issues"
+  },
+  "homepage": "https://github.com/WorkingScholar/workingscholar"
+}


### PR DESCRIPTION
This adds [npm](https://www.npmjs.com/package/npm) configurations so we can start managing our front-end dependencies in a sensible manner.
