### PR TITLE
Add Devise for user authentication

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - "bin/*"
     - "vendor/**/*"
     - "db/schema.rb"
+    - "db/migrate/*"
   RunRailsCops: true
 
 Metrics/LineLength:

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,9 @@ gem "turbolinks"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jbuilder", "~> 2.0"
 
+# Use devise for user authentication
+gem "devise"
+
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
   gem "sdoc", "~> 0.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
+    bcrypt (3.1.10)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -51,6 +52,13 @@ GEM
       execjs
     coffee-script-source (1.9.1)
     debug_inspector (0.0.2)
+    devise (3.4.1)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 3.2.6, < 5)
+      responders
+      thread_safe (~> 0.1)
+      warden (~> 1.2.3)
     erubis (2.7.0)
     execjs (2.4.0)
     globalid (0.3.3)
@@ -75,6 +83,7 @@ GEM
     multi_json (1.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    orm_adapter (0.5.0)
     parser (2.2.0.3)
       ast (>= 1.1, < 3.0)
     pg (0.18.1)
@@ -117,6 +126,8 @@ GEM
     rake (10.4.2)
     rdoc (4.2.0)
       json (~> 1.4)
+    responders (2.1.0)
+      railties (>= 4.2.0, < 5)
     rubocop (0.29.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.0.1, < 3.0)
@@ -154,6 +165,8 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    warden (1.2.3)
+      rack (>= 1.0)
     web-console (2.1.2)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
@@ -165,6 +178,7 @@ PLATFORMS
 
 DEPENDENCIES
   coffee-rails (~> 4.1.0)
+  devise
   jbuilder (~> 2.0)
   jquery-rails
   pg

--- a/app/assets/stylesheets/_alert.scss
+++ b/app/assets/stylesheets/_alert.scss
@@ -1,0 +1,4 @@
+.alert {
+  padding: 0.75rem 0;
+  text-align: center;
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -2,4 +2,6 @@
 
 @import "materialize";
 
+@import "alert";
+
 @import "home";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,6 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  before_action :authenticate_account!
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  skip_before_action :authenticate_account!, only: [:index]
+
   def index
     #
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,0 +1,4 @@
+class Account < ActiveRecord::Base
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+end

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,32 @@
+<div class="container">
+  <div class="row">
+    <h3>Password Reset</h3>
+  </div>
+
+  <div class="row">
+    <%= form_for resource,
+      as: resource_name,
+      url: password_path(resource_name),
+      html: { method: :post } do |f| %>
+
+      <div class="row">
+        <div class="input-field col s12">
+          <%= f.email_field :email, autofocus: true, class: "validate" %>
+          <%= f.label :email %>
+        </div>
+      </div>
+
+      <div class="actions">
+        <button class="btn waves-effect waves-light" type="submit" name="action">Send Reset Instructions
+          <i class="mdi-content-send right"></i>
+        </button>
+      </div>
+
+    <% end %>
+  </div>
+
+  <div class="row">
+    <%= render "devise/shared/links" %>
+  </div>
+
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,66 @@
+<div class="container">
+  <div class="row">
+    <h3>Edit <%= resource_name.to_s.humanize %></h3>
+  </div>
+
+  <div class="row">
+    <%= form_for resource,
+      as: resource_name,
+      url: registration_path(resource_name),
+      html: { method: :put } do |f| %>
+      <%= devise_error_messages! %>
+
+      <div class="row">
+        <div class="input-field col s12">
+          <%= f.email_field :email, class: "validate" %>
+          <%= f.label :email %>
+        </div>
+      </div>
+
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+      <% end %>
+
+      <div class="row">
+        <div class="input-field col s12">
+          <%= f.password_field :current_password, autocomplete: "off", class: "validate" %>
+          <%= f.label :current_password, "Old password" %>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="input-field col s12">
+          <%= f.password_field :password, autocomplete: "off", class: "validate" %>
+          <%= f.label :password, "New password (8 characters minimum)" %>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="input-field col s12">
+          <%= f.password_field :password_confirmation, autocomplete: "off", class: "validate" %>
+          <label for:"password-confirmation">Confirm new password</label>
+        </div>
+      </div>
+
+      <div class="actions">
+        <button class="btn waves-effect waves-light" type="submit" name="action">Submit
+          <i class="mdi-content-send right"></i>
+        </button>
+      </div>
+    <% end %>
+
+    <h3>Cancel account</h3>
+
+    <div class="row">
+      <%= button_to registration_path(resource_name),
+        data: { confirm: "Are you sure you want to delete your account?" },
+        method: :delete,
+        class: "red darken-2 btn waves-effect waves-light",
+        style: "margin-top: 15px" do %>
+        Delete Account<i class="mdi-action-highlight-remove right"></i>
+      <% end %>
+    </div>
+
+    <%= link_to "Back", :back %>
+  </div>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,46 @@
+<div class="container">
+  <div class="row">
+    <h3>Sign up</h3>
+  </div>
+
+  <div class="row">
+    <%= form_for resource,
+      as: resource_name,
+      url: registration_path(resource_name),
+      html: { class: "" } do |f| %>
+      <%= devise_error_messages! %>
+
+      <div class="row">
+        <div class="input-field col s12">
+          <%= f.email_field :email, class: "validate" %>
+          <%= f.label :email %>
+        </div>
+      </div>
+
+      <% if @validatable %>
+        <div class="row">
+          <div class="input-field col s12">
+            <%= f.password_field :password, autocomplete: "off", class: "validate" %>
+            <%= f.label :password, "Password (8 characters minimum)" %>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="input-field col s12">
+            <%= f.password_field :password_confirmation, autocomplete: "off", class: "validate" %>
+            <label for:"password-confirmation">Confirm Password</label>
+          </div>
+        </div>
+      <% end %>
+
+      <div class="actions">
+        <button class="btn waves-effect waves-light" type="submit" name="action">Submit
+          <i class="mdi-content-send right"></i>
+        </button>
+      </div>
+
+    <% end %>
+
+    <%= render "devise/shared/links" %>
+  </div>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,48 @@
+<div class="container">
+  <div class="row">
+    <h3>Log in</h3>
+  </div>
+
+  <div class="row">
+    <%= form_for resource,
+      as: resource_name,
+      url: session_path(resource_name),
+      html: { class: "" } do |f| %>
+
+      <div class="row">
+        <div class="input-field col s12">
+          <%= f.email_field :email, autofocus: true, class: "validate" %>
+          <%= f.label :email %>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="input-field col s12">
+          <%= f.password_field :password, autocomplete: "off", class: "validate" %>
+          <%= f.label :password %>
+        </div>
+      </div>
+
+      <% if devise_mapping.rememberable? %>
+        <div class="row">
+          <p style="padding: 0 0.75rem">
+            <%= f.check_box :remember_me %>
+            <%= f.label :remember_me %>
+          </p>
+        </div>
+      <% end %>
+
+      <div class="actions">
+        <button class="btn waves-effect waves-light" type="submit" name="action">Submit
+          <i class="mdi-content-send right"></i>
+        </button>
+      </div>
+
+    <% end %>
+  </div>
+
+  <div class="row">
+    <%= render "devise/shared/links" %>
+  </div>
+
+</div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Login", new_session_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Register", new_registration_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider) %><br />
+  <% end -%>
+<% end -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,11 +9,13 @@
 </head>
 <body>
 
-<%= render "shared/navbar" %>
+  <%= render "shared/navbar" %>
 
-<%= yield %>
+  <%= render "shared/notifications" %>
 
-<%= render "shared/footer" %>
+  <%= yield %>
+
+  <%= render "shared/footer" %>
 
 </body>
 </html>

--- a/app/views/shared/_alert.html.erb
+++ b/app/views/shared/_alert.html.erb
@@ -1,0 +1,7 @@
+<div class="red lighten-3 z-depth-1">
+  <div class="container">
+    <div class="alert red-text darken-3">
+      <%= alert %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_notice.html.erb
+++ b/app/views/shared/_notice.html.erb
@@ -1,0 +1,7 @@
+<div class="light-blue lighten-3 z-depth-1">
+  <div class="container">
+    <div class="alert light-blue-text darken-3">
+      <%= notice %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_notifications.html.erb
+++ b/app/views/shared/_notifications.html.erb
@@ -1,0 +1,6 @@
+  <% if notice %>
+    <%= render "shared/notice" %>
+  <% end %>
+  <% if alert %>
+    <%= render "shared/alert" %>
+  <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,6 +16,10 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.default_url_options = { host: "localhost",
+                                               port: 3000
+                                             }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,6 +65,10 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.default_url_options = { host: "workingscholar.herokuapp.com",
+                                               port: 3000
+                                             }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,265 @@
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  #
+  # rubocop:disable Metrics/LineLength
+  # config.secret_key = '98f50b6941ed8b5f380f23a8bb2a460716688aa75daf211e4db348a25f9ddbb29d074e72a1668845c4760ef8f1ed83b1b2677ae9c95d82a5d0e9dd96af449967'
+  # rubocop:enable Metrics/LineLength
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require "devise/orm/active_record"
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [ :email ]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication. The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 10. If
+  # using other encryptors, it sets how many times you want the password re-encrypted.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # encryptor), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 10
+
+  # Setup a pepper to generate the encrypted password.
+  #
+  # rubocop:disable Metrics/LineLength
+  # config.pepper = 'd490fc5cb6abb3b5a9d70c366786930c258504e918c84176a2258111bdadf0ec818761137d19fcb8d71045dce8df9cbaf3ba138f97f269f583a60698b0b1c7cd'
+  # rubocop:enable Metrics/LineLength
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day. Default is 0.days, meaning
+  # the user cannot access the website without confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [ :email ]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 8..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  # config.email_regexp = /\A[^@]+@[^@]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # If true, expires auth token on session timeout.
+  # config.expire_auth_token_on_timeout = false
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [ :email ]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [ :email ]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another encryption algorithm besides bcrypt (default). You can use
+  # :sha1, :sha512 or encryptors from others authentication tools as :clearance_sha1,
+  # :authlogic_sha512 (then you should set stretches above to 20 for default behavior)
+  # and :restful_authentication_sha1 (then you should set stretches to 10, and copy
+  # REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using omniauth, Devise cannot automatically set Omniauth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,60 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,21 @@
 Rails.application.routes.draw do
   root "home#index"
+
+  devise_for :accounts,
+             sign_out_via: [:get, :delete],
+             skip: [:sessions, :passwords],
+             path_names: { sign_up: "register" }
+  as :account do
+    # Sessions
+    get "login",    to: "devise/sessions#new",     as: :new_account_session
+    post "login",   to: "devise/sessions#create",  as: :account_session
+    match "logout", to: "devise/sessions#destroy", as: :destroy_account_session,
+                    via: Devise.mappings[:account].sign_out_via
+
+    # Passwords
+    get "account/password_reset",  to: "devise/passwords#new",    as: :new_account_password
+    post "account/password_reset", to: "devise/passwords#create", as: :account_password
+    patch "account/password",      to: "devise/passwords#update"
+    put "account/password",        to: "devise/passwords#upate"
+  end
 end

--- a/db/migrate/20150407022938_devise_create_accounts.rb
+++ b/db/migrate/20150407022938_devise_create_accounts.rb
@@ -1,0 +1,21 @@
+class DeviseCreateAccounts < ActiveRecord::Migration
+  def change
+    create_table(:accounts) do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      t.timestamps null: false
+    end
+
+    add_index :accounts, :email,                unique: true
+    add_index :accounts, :reset_password_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,32 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20150407022938) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "accounts", force: :cascade do |t|
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+  end
+
+  add_index "accounts", ["email"], name: "index_accounts_on_email", unique: true, using: :btree
+  add_index "accounts", ["reset_password_token"], name: "index_accounts_on_reset_password_token", unique: true, using: :btree
+
+end

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+#  column: value

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AccountTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Obsoletes #17.

Progress towards #12, #18.

This adds [Devise](https://github.com/plataformatec/devise) for handling user authentication, and implements a basic Account model to which subsequent types of users will be associated.  This association centralizes the basic user logic that deals with user creation and authentication.
##### Routes:

This also makes some changes the default Devise session routes, which are summarized in the table below:

| HTTP Verb | Default | New Path | Scope/Controller#Action | Named Helper |
| --- | --- | --- | --- | --- |
| GET | `/sign_in` | `/login` | devise/sessions#new | `new_account_session` |
| POST | `/sign_in` | `/login` | devise/sessions#create | `account_session` |
| GET/DELETE | `/sign_out` | `/logout` | devise/sessions#destroy | `destroy_account_session` |
| GET | `/accounts/sign_up` | `/accounts/register` | devise/registrations#new | `new_account_registration` |
| GET | `/accounts/passwords/new` | `/account/password_reset` | devise/passwords#new | `new_account_password` |
| POST | `/accounts/passwords` | `/account/password_reset` | devise/passwords#create | `account_password` |

The following paths have been removed:
- GET `/accounts/password/edit`

They will be re-implemented for each subsequent type of user account.
##### Authentication:

We'll take a whitelist approach to set the pages that unauthenticated users are allowed to access.

An example of whitelisting a controller action can be found in `app/controllers/home_controller.rb`.  To whitelist a controller action, add:

```
skip_before_action :authenticate_account!, only: [:<action>]
```

under the `Class` declaration.

If `skip_before_action` is already present, simply add the action you want to whitelist to the `only:` array.

Currently, only `root` (`home#index`) and `/account/password_reset` are whitelisted.
##### Rubocop Linting:

Tell Rubocop to ignore everything under `db/migration/*`.  Migrations are auto-generated by Rails, we don't want to be editing them manually just to conform to Rubocop linting guidelines.
##### Views:

Add and style some shared views for `/register`, `/login`, `/reset_password`, `/accounts/edit`, as well as basic styling for Rails `notice` and `alert` required by Devise.
