### PR TITLE
Fix username presence validation

### DIFF
--- a/app/models/employer.rb
+++ b/app/models/employer.rb
@@ -2,8 +2,8 @@ class Employer < ActiveRecord::Base
   extend FriendlyId
   friendly_id :username
 
+  validates :username, presence: true, uniqueness: { case_sensitive: false }
   validates :name, presence: true
-  validates :username, uniqueness: { case_sensitive: false }
 
   has_one :account
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -4,7 +4,7 @@ class Student < ActiveRecord::Base
   extend FriendlyId
   friendly_id :username
 
-  validates :username, uniqueness: { case_sensitive: false }
+  validates :username, presence: true, uniqueness: { case_sensitive: false }
   validates :first_name, presence: true
   validates :last_name, presence: true
 


### PR DESCRIPTION
It turns out that `uniqueness` validations do not imply the existence of `presence` validations.  See the [Rails documentation on validations](http://guides.rubyonrails.org/active_record_validations.html#presence).

Previously, `:username` could be set to `nil` or empty string and the validations would still pass.  This fixes `:username` validations on both Student and Employer to ensure that the field is present, **as well as** unique.
