### PR TITLE
Redirect authenticated accounts to their profile instead of landing page

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,6 +1,10 @@
 class ProfileController < ApplicationController
   before_action :set_profile, only: [:show]
 
+  def root
+    redirect_to profile_path(current_account)
+  end
+
   private
 
     def set_profile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  authenticated :account do
+    root to: "profile#root", as: :authenticated_root
+  end
   root "home#index"
 
   scope :profile do


### PR DESCRIPTION
This prevents authenticated accounts from hitting the useless-for-registered-users landing page.
