### PR TITLE
Fix PostingApplication so Students can apply to Posting

### DIFF
--- a/app/models/posting.rb
+++ b/app/models/posting.rb
@@ -6,6 +6,6 @@ class Posting < ActiveRecord::Base
   validates :compensation, inclusion: { in: %w(Pay Referral) }
 
   def applied?(student)
-    PostingApplication.where(student: student, posting: self)
+    PostingApplication.where(student: student, posting: self).length > 0
   end
 end


### PR DESCRIPTION
`PostingApplication#where` returns an array, which is always a "truthy" value.  Update logic to determine "truthiness" based on length of array.
