### PR TITLE
Implement partial dates for ResumeEntries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem "redcarpet"
 # Filepicker
 gem "filepicker-rails"
 
+# Partial date storage & retrieval
+gem "partial-date", git: "https://github.com/0xazure/partial-date.git"
+
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
   gem "sdoc", "~> 0.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/0xazure/partial-date.git
+  revision: 2f9fda144de9ba9040c81f492014224c160fecea
+  specs:
+    partial-date (1.2.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -194,6 +200,7 @@ DEPENDENCIES
   gravatar-ultimate
   jbuilder (~> 2.0)
   jquery-rails
+  partial-date!
   pg
   puma
   rails (= 4.2.1)

--- a/app/controllers/resume_entries_controller.rb
+++ b/app/controllers/resume_entries_controller.rb
@@ -44,9 +44,10 @@ class ResumeEntriesController < ApplicationController
       params.require(:resume_entry)
         .permit(:job_title,
                 :employer_name,
-                :start_date,
-                :end_date,
-                :description
+                :description,
+                :current,
+                start_date: [:year, :month, :day],
+                end_date: [:year, :month, :day]
                )
     end
 end

--- a/app/helpers/resume_entries_helper.rb
+++ b/app/helpers/resume_entries_helper.rb
@@ -1,2 +1,33 @@
+require "partial-date"
+
 module ResumeEntriesHelper
+  def stringify_partial_date(partial_date)
+    if partial_date == 0 || partial_date == -1
+      partial_date
+    else
+      date = PartialDate::Date.load(partial_date)
+      format_date date
+    end
+  end
+
+  def format_date(date)
+    if date.year.present? && date.month.present? && date.day.present?
+      date.to_s("%B %e, %Y")
+    elsif date.year.present? && date.month.present?
+      date.to_s("%B %Y")
+    else
+      date.to_s("%Y")
+    end
+  end
+
+  def resume_date_span(start_date, end_date, present)
+    date_span = ""
+    date_span << stringify_partial_date(start_date) if start_date > 0
+    date_span << " to " if start_date != 0 && end_date != 0
+    if present
+      date_span << "Present"
+    else
+      date_span << stringify_partial_date(end_date)
+    end
+  end
 end

--- a/app/models/resume_entry.rb
+++ b/app/models/resume_entry.rb
@@ -1,3 +1,5 @@
+require "partial-date"
+
 class ResumeEntry < ActiveRecord::Base
   validates :student, presence: true
   validates :job_title, presence: true
@@ -7,4 +9,20 @@ class ResumeEntry < ActiveRecord::Base
   belongs_to :student
 
   belongs_to :employer
+
+  def loaded_partial_date(date)
+    if date == -1
+      0
+    else
+      PartialDate::Date.load date
+    end
+  end
+
+  def loaded_partial_start_date
+    loaded_partial_date partial_start_date
+  end
+
+  def loaded_partial_end_date
+    loaded_partial_date partial_end_date
+  end
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -19,6 +19,6 @@ class Student < ActiveRecord::Base
   belongs_to :major, counter_cache: true
   delegate :name, to: :major, prefix: true, allow_nil: true
 
-  has_many :resume_entries, -> { order "end_date DESC" }
+  has_many :resume_entries, -> { order "abs(partial_end_date) DESC" }
   has_many :posting_applications
 end

--- a/app/views/resume_entries/_entry.html.erb
+++ b/app/views/resume_entries/_entry.html.erb
@@ -28,10 +28,10 @@
           <% end %>
         </div>
         <div class="duration">
-          <% if entry.start_date.present? && entry.end_date.present? %>
-            <i class="fa fa-calendar-o"></i><%= entry.start_date %> to <%= entry.end_date %>
-          <% else %>
+          <% if entry.partial_start_date == 0 && entry.partial_end_date == 0 %>
             <i class="fa fa-calendar-o"></i><span class="grey-text lighten-2">No information</span>
+          <% else %>
+            <i class="fa fa-calendar-o"></i><%= resume_date_span entry.partial_start_date, entry.partial_end_date, entry.current %>
           <% end %>
         </div>
       </div>

--- a/app/views/resume_entries/_form.html.erb
+++ b/app/views/resume_entries/_form.html.erb
@@ -1,26 +1,114 @@
-<div class="input-field col s12">
-  <%= f.text_field :job_title %>
-  <%= f.label :job_title %><br>
-</div>
-<div class="input-field col s12">
-  <%= f.text_field :employer_name %>
-  <%= f.label :employer_name %><br>
-</div>
-<div class="input-field col s6">
-  <input id="resume_entry_start_date" class="datepicker" type="date" name="resume_entry[start_date]">
-  <%= f.label :start_date %>
-</div>
-<div class="input-field col s6">
-  <input id="resume_entry_end_date" class="datepicker" type="date" name="resume_entry[end_date]">
-  <%= f.label :end_date %>
-</div>
-<div class="input-field col s12">
-  <%= f.text_area :description, class: "materialize-textarea" %>
-  <%= f.label :description %>
+<div class="row">
+  <div class="input-field col s12">
+    <%= f.text_field :job_title %>
+    <%= f.label :job_title %><br>
+  </div>
 </div>
 
-<div class="actions input-field col s12">
-  <button class="btn waves-effect waves-light" type="submit" name="action"><%= button_text %>
-    <i class="mdi-content-send right"></i>
-  </button>
+<div class="row">
+  <div class="input-field col s12">
+    <%= f.text_field :employer_name %>
+    <%= f.label :employer_name %><br>
+  </div>
+</div>
+
+<div class="row">
+  <div class="input-field col s5">
+    <small class="grey-text">Start date</small>
+    <div id="resume_entry_start_date" class="select-wrapper">
+      <div class="col s3">
+        <%= select_year entry.loaded_partial_start_date.year,
+                        {
+                          start_year: 10.years.from_now.year,
+                          end_year: 1950,
+                          prompt: "Year",
+                          prefix: "resume_entry[start_date]"
+                        },
+                        {
+                          class: "browser-default"
+                        } %>
+      </div>
+      <div class="col s3">
+        <%= select_month entry.loaded_partial_start_date.month,
+                         {
+                           use_short_month: true,
+                           prompt: "Month",
+                           prefix: "resume_entry[start_date]"
+                         },
+                         {
+                           class: "browser-default"
+                         } %>
+      </div>
+      <div class="col s3">
+        <%= select_day entry.loaded_partial_start_date.day,
+                         {
+                           prompt: "Day",
+                           prefix: "resume_entry[start_date]"
+                         },
+                         {
+                           class: "browser-default"
+                         } %>
+      </div>
+    </div>
+  </div>
+
+  <div class="input-field col s5">
+    <small class="grey-text">End date</small>
+    <div id="resume_entry_end_date" class="select-wrapper">
+      <div class="col s3">
+        <%= select_year entry.loaded_partial_end_date.year,
+                        {
+                          start_year: 10.years.from_now.year,
+                          end_year: 1950,
+                          prompt: "Year",
+                          prefix: "resume_entry[end_date]"
+                        },
+                        {
+                          class: "browser-default"
+                        } %>
+      </div>
+      <div class="col s3">
+        <%= select_month entry.loaded_partial_end_date.month,
+                         {
+                           use_short_month: true,
+                           prompt: "Month",
+                           prefix: "resume_entry[end_date]"
+                         },
+                         {
+                           class: "browser-default"
+                         } %>
+      </div>
+      <div class="col s3">
+        <%= select_day entry.loaded_partial_end_date.day,
+                         {
+                           prompt: "Day",
+                           prefix: "resume_entry[end_date]"
+                         },
+                         {
+                           class: "browser-default"
+                         } %>
+      </div>
+    </div>
+  </div>
+
+  <div class="input-field col s2">
+    <p>
+      <%= f.check_box :current %>
+      <%= f.label :current %>
+    </p>
+  </div>
+</div>
+<div class="row">
+  <div class="input-field col s12">
+    <%= f.text_area :description, class: "materialize-textarea" %>
+    <%= f.label :description %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="actions input-field col s12">
+    <button class="btn waves-effect waves-light" type="submit" name="action"><%= button_text %>
+      <i class="mdi-content-send right"></i>
+    </button>
+  </div>
 </div>

--- a/db/migrate/20150503180300_change_date_to_flexdate.rb
+++ b/db/migrate/20150503180300_change_date_to_flexdate.rb
@@ -1,0 +1,51 @@
+require "partial-date"
+
+class ChangeDateToFlexdate < ActiveRecord::Migration
+  def up
+    add_column :resume_entries, :partial_start_date, :integer, default: 0
+    add_column :resume_entries, :partial_end_date, :integer, default: 0
+    add_column :resume_entries, :current, :boolean, default: false
+
+    ResumeEntry.reset_column_information
+
+    ResumeEntry.all.each do |entry|
+      start_date = entry.start_date
+      end_date = entry.end_date
+      partial_start = PartialDate::Date.new do |d|
+        d.year = start_date.year.to_s
+        d.month = start_date.month.to_s.rjust(2, "0")
+        d.day = start_date.day.to_s.rjust(2, "0")
+      end
+      partial_end = PartialDate::Date.new do |d|
+        d.year = end_date.year.to_s
+        d.month = end_date.month.to_s.rjust(2, "0")
+        d.day = end_date.day.to_s.rjust(2, "0")
+      end
+      entry.update_attributes partial_start_date: partial_start.value, partial_end_date: partial_end.value
+      entry.save
+    end
+
+    remove_column :resume_entries, :start_date
+    remove_column :resume_entries, :end_date
+  end
+
+  def down
+    add_column :resume_entries, :start_date, :date
+    add_column :resume_entries, :end_date, :date
+
+    ResumeEntry.reset_column_information
+
+    ResumeEntry.all.each do |entry|
+      partial_start_date = PartialDate::Date.load entry.partial_start_date
+      partial_end_date = PartialDate::Date.load entry.partial_end_date
+      start_date = Date.parse(partial_start_date.to_s(:long))
+      end_date = Date.parse(partial_end_date.to_s(:long))
+      entry.update_attributes start_date: start_date, end_date: end_date
+      entry.save
+    end
+
+    remove_column :resume_entries, :partial_start_date
+    remove_column :resume_entries, :partial_end_date
+    remove_column :resume_entries, :current
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,11 +98,12 @@ ActiveRecord::Schema.define(version: 20150503191801) do
     t.string   "job_title"
     t.string   "employer_name"
     t.integer  "employer_id"
-    t.string   "start_date"
-    t.string   "end_date"
     t.text     "description"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
+    t.integer  "partial_start_date", default: 0
+    t.integer  "partial_end_date",   default: 0
+    t.boolean  "current",            default: false
   end
 
   add_index "resume_entries", ["employer_id"], name: "index_resume_entries_on_employer_id", using: :btree

--- a/lib/resume_entry_params.rb
+++ b/lib/resume_entry_params.rb
@@ -1,20 +1,42 @@
+require "partial-date"
+
 class ResumeEntryParams
   def self.build(params)
     munged_params = params.dup
-    coerce_start_to_date!(munged_params)
-    coerce_end_to_date!(munged_params)
+    coerce_start_to_partial_date!(munged_params)
+    coerce_end_to_partial_date!(munged_params)
     munged_params
   end
 
   class << self
     private
 
-      def coerce_start_to_date!(params)
-        params[:start_date] = Date.parse(params[:start_date]) if params[:start_date].present?
+      def coerce_start_to_partial_date!(params)
+        start_params = params[:start_date]
+        if start_params[:year].blank? && start_params[:month].blank? && start_params[:day].blank?
+          params[:partial_start_date] = 0
+        else
+          params[:partial_start_date] = build_partial_date(start_params).value
+        end
+        params.delete(:start_date)
       end
 
-      def coerce_end_to_date!(params)
-        params[:end_date] = Date.parse(params[:end_date]) if params[:end_date].present?
+      def coerce_end_to_partial_date!(params)
+        end_params = params[:end_date]
+        if end_params[:year].blank? && end_params[:month].blank? && end_params[:day].blank?
+          params[:partial_end_date] = 0
+        else
+          params[:partial_end_date] = build_partial_date(end_params).value
+        end
+        params.delete(:end_date)
+      end
+
+      def build_partial_date(date_params)
+        PartialDate::Date.new do |d|
+          d.year = date_params[:year]
+          d.month = date_params[:month].rjust(2, "0")
+          d.day = date_params[:day].rjust(2, "0")
+        end
       end
   end
 end


### PR DESCRIPTION
Closes #32.

Implement partial dates for ResumeEntries.

We're using a gem called [partial-date](https://github.com/58bits/partial-date) for databacking of partial dates.  I had to use [my own fork](https://github.com/0xazure/partial-date) of the gem though, because there was some functionality I had to patch to get it to display things properly.
